### PR TITLE
Updated creation property recommendations

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -364,7 +364,7 @@ pre {
         <td></td>
         <td>pav:createdOn</td>
         <td>xsd:dateTime</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>
@@ -373,7 +373,7 @@ pre {
         <td></td>
         <td>pav:authoredOn</td>
         <td>xsd:dateTime</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>
@@ -382,7 +382,7 @@ pre {
         <td></td>
         <td>pav:curatedOn</td>
         <td>xsd:dateTime</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>
@@ -400,7 +400,7 @@ pre {
         <td></td>
         <td>dct:contributor</td>
         <td>IRI or xsd:string</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>
@@ -409,7 +409,7 @@ pre {
         <td></td>
         <td>pav:createdBy</td>
         <td>IRI or xsd:string</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>
@@ -418,7 +418,7 @@ pre {
         <td></td>
         <td>pav:authoredBy</td>
         <td>IRI or xsd:string</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>
@@ -427,7 +427,7 @@ pre {
         <td></td>
         <td>pav:curatedBy</td>
         <td>IRI or xsd:string</td>
-        <td>MAY</td>
+        <td>NEVER</td>
         <td>MAY</td>
         <td>MAY</td>
         <td>Fine-grained assignation of the creation task</td>


### PR DESCRIPTION
We agreed in the last call that these should be set to NEVER for the Summary level description to be consistent with the dct:created property recommendation
